### PR TITLE
Fix Doc and clear Dockerfile

### DIFF
--- a/Context/Dockerfile
+++ b/Context/Dockerfile
@@ -3,9 +3,7 @@ FROM ubuntu:focal
 LABEL maintainer "VCityTeam"
 LABEL source.repo "https://github.com/VCityTeam/UD-Viz-docker"
 
-ARG UD_VIZ_EXAMPLES_PORT
-ENV UD_VIZ_EXAMPLES_PORT=${UD_VIZ_EXAMPLES_PORT}
-
+# Install system dependencies
 RUN apt-get update
 
 # Node version 16 is required. For its installation (on focal) refer to e.g.
@@ -31,6 +29,5 @@ WORKDIR UD-SimpleServer
 RUN git checkout cors-issues
 RUN npm install
 
-EXPOSE ${UD_VIZ_EXAMPLES_PORT}
-# CMD [ "node", "./index.js", "../UD-Viz", "${UD_VIZ_EXAMPLES_PORT}" ]
+EXPOSE 80
 CMD [ "node", "./index.js", "../UD-Viz", "80" ]

--- a/Readme.md
+++ b/Readme.md
@@ -12,15 +12,15 @@ docker build -t vcity:ud-viz-examples Context
 Then run the container e.g. with
 
 ```bash
-docker run [--detach] --env UD_VIZ_EXAMPLES_PORT=8080 --rm -t vcity:ud-viz-examples
+docker run -p 0.0.0.0:8080:80/tcp [--detach] --rm -t vcity:ud-viz-examples
 ```
 
 and open a web browser on URL `http://localhost:8080/`
 
 Notes:
 
-- in the above `docker run` command the optionnal `-d` argument requires the
+- in the above `docker run` command the optionnal `--detach` argument requires the
   container to run in detached mode,
-- the published port (the `8080` in the above `-p` flag argument of the the 
+- the published port (the `8080` in the above `-p` flag argument of the the
   `docker run` command) can be changed but has to match with the port given
   (within the URL) when browsing


### PR DESCRIPTION
Readme:
- The line that allowed to run the docker container was missing the port forwarding part. (-p)

Dockerfile:
- Removal of the ARG and ENV docker instructions. Unnecessary, because they were only used to change the port to be exposed in the EXPOSE instruction. EXPOSE is a documentation instruction and is not intended to change.
